### PR TITLE
feat: add achievement and badge system

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,8 @@ import { LeaderboardModule } from './leaderboard/leaderboard.module';
 import { GameSessionModule } from './game-session/game-session.module';
 import { ChallengeModule } from './challenge/challenge.module';
 import { MailModule } from './mail/mail.module';
+import { BadgeModule } from './badge/badge.module';
+import { GameModule } from './game/game.module';
 
 
 @Module({
@@ -62,6 +64,8 @@ import { MailModule } from './mail/mail.module';
     GameSessionModule,
     ChallengeModule,
     MailModule,
+    BadgeModule,
+    GameModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/guards/admin.guard.ts
+++ b/src/auth/guards/admin.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { AuthGuard } from './auth.guard';
+import type { User } from '../../user/entities/user.entity';
+
+@Injectable()
+export class AdminGuard extends AuthGuard implements CanActivate {
+  constructor(
+    jwtService: any,
+    private userRepository: Repository<User>,
+  ) {
+    super(jwtService);
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isAuthenticated = await super.canActivate(context);
+    if (!isAuthenticated) return false;
+
+    const request = context.switchToHttp().getRequest();
+    const user = await this.userRepository.findOne({
+      where: { id: request.user.id },
+    });
+
+    if (!user?.isAdmin) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    return true;
+  }
+}

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  type CanActivate,
+  type ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { JwtService } from '@nestjs/jwt';
+import type { Request } from 'express';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private jwtService: JwtService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Access token not found');
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      request.user = payload;
+      return true;
+    } catch (error) {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+  }
+
+  private extractTokenFromHeader(request: Request): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/src/badge/badge.controller.spec.ts
+++ b/src/badge/badge.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadgeController } from './badge.controller';
+import { BadgeService } from './badge.service';
+
+describe('BadgeController', () => {
+  let controller: BadgeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BadgeController],
+      providers: [BadgeService],
+    }).compile();
+
+    controller = module.get<BadgeController>(BadgeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/badge/badge.controller.ts
+++ b/src/badge/badge.controller.ts
@@ -1,0 +1,131 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  ParseUUIDPipe,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import type { BadgeService } from '../services/badge.service';
+import type { AchievementService } from '../services/achievement.service';
+import type { CreateBadgeDto } from '../dto/create-badge.dto';
+import type { AwardBadgeDto } from '../dto/award-badge.dto';
+import { AuthGuard } from '../../auth/guards/auth.guard';
+import { AdminGuard } from '../../auth/guards/admin.guard';
+import type { AchievementType } from '../entities/badge.entity';
+
+@Controller('badges')
+export class BadgeController {
+  constructor(
+    private readonly badgeService: BadgeService,
+    private readonly achievementService: AchievementService,
+  ) {}
+
+  @Post()
+  @UseGuards(AdminGuard)
+  async createBadge(createBadgeDto: CreateBadgeDto) {
+    return await this.badgeService.createBadge(createBadgeDto);
+  }
+
+  @Get()
+  async getAllBadges(
+    @Query('includeInactive') includeInactive?: string,
+    @Query('type') type?: AchievementType,
+  ) {
+    if (type) {
+      return await this.badgeService.getBadgesByType(type);
+    }
+    return await this.badgeService.getAllBadges(includeInactive === 'true');
+  }
+
+  @Get('leaderboard')
+  async getLeaderboard(
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    return await this.badgeService.getLeaderboardWithBadges(limit);
+  }
+
+  @Get(':id')
+  async getBadgeById(@Param('id', ParseUUIDPipe) id: string) {
+    return await this.badgeService.getBadgeById(id);
+  }
+
+  @Put(':id')
+  @UseGuards(AdminGuard)
+  async updateBadge(
+    @Param('id', ParseUUIDPipe) id: string,
+    updateData: Partial<CreateBadgeDto>,
+  ) {
+    return await this.badgeService.updateBadge(id, updateData);
+  }
+
+  @Delete(':id')
+  @UseGuards(AdminGuard)
+  async deactivateBadge(@Param('id', ParseUUIDPipe) id: string) {
+    return await this.badgeService.deactivateBadge(id);
+  }
+
+  @Post('award')
+  @UseGuards(AdminGuard)
+  async awardBadge(awardBadgeDto: AwardBadgeDto, @Request() req) {
+    return await this.badgeService.awardBadgeManually(
+      awardBadgeDto,
+      req.user.id,
+    );
+  }
+
+  @Get('user/:userId')
+  @UseGuards(AuthGuard)
+  async getUserBadges(@Param('userId', ParseUUIDPipe) userId: string) {
+    return await this.badgeService.getUserBadges(userId);
+  }
+
+  @Get('user/:userId/profile')
+  @UseGuards(AuthGuard)
+  async getUserProfileBadges(@Param('userId', ParseUUIDPipe) userId: string) {
+    return await this.badgeService.getUserProfileBadges(userId);
+  }
+
+  @Get('user/:userId/progress/:badgeId')
+  @UseGuards(AuthGuard)
+  async getBadgeProgress(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Param('badgeId', ParseUUIDPipe) badgeId: string,
+  ) {
+    return await this.badgeService.getBadgeProgress(userId, badgeId);
+  }
+
+  @Delete('user/:userId/badge/:badgeId')
+  @UseGuards(AdminGuard)
+  async removeBadgeFromUser(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Param('badgeId', ParseUUIDPipe) badgeId: string,
+  ) {
+    return await this.badgeService.removeBadgeFromUser(userId, badgeId);
+  }
+
+  @Post('check-achievements/:userId')
+  @UseGuards(AuthGuard)
+  async checkAchievements(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    context?: any,
+  ) {
+    return await this.achievementService.checkAndAwardAchievements(
+      userId,
+      context,
+    );
+  }
+
+  @Post('initialize-defaults')
+  @UseGuards(AdminGuard)
+  async initializeDefaultBadges() {
+    await this.achievementService.initializeDefaultBadges();
+    return { message: 'Default badges initialized successfully' };
+  }
+}

--- a/src/badge/badge.module.ts
+++ b/src/badge/badge.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BadgeController } from './controllers/badge.controller';
+import { BadgeService } from './services/badge.service';
+import { AchievementService } from './services/achievement.service';
+import { Badge } from './entities/badge.entity';
+import { UserBadge } from './entities/user-badge.entity';
+import { Game } from '../game/entities/game.entity';
+import { User } from 'src/users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Badge, UserBadge, User, Game])],
+  controllers: [BadgeController],
+  providers: [BadgeService, AchievementService],
+  exports: [BadgeService, AchievementService],
+})
+export class BadgeModule {}

--- a/src/badge/badge.service.spec.ts
+++ b/src/badge/badge.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadgeService } from './badge.service';
+
+describe('BadgeService', () => {
+  let service: BadgeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BadgeService],
+    }).compile();
+
+    service = module.get<BadgeService>(BadgeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/badge/dto/award-badge.dto.ts
+++ b/src/badge/dto/award-badge.dto.ts
@@ -1,0 +1,19 @@
+import { IsOptional, IsObject, IsUUID } from 'class-validator';
+
+export class AwardBadgeDto {
+  @IsUUID()
+  userId: string;
+
+  @IsUUID()
+  badgeId: string;
+
+  @IsObject()
+  @IsOptional()
+  metadata?: {
+    gameId?: string;
+    score?: number;
+    context?: string;
+    triggerEvent?: string;
+    additionalData?: Record<string, any>;
+  };
+}

--- a/src/badge/dto/badge-response.dto.ts
+++ b/src/badge/dto/badge-response.dto.ts
@@ -1,0 +1,39 @@
+import type { AchievementType, BadgeRarity } from '../entities/badge.entity';
+
+export class BadgeResponseDto {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  type: AchievementType;
+  rarity: BadgeRarity;
+  points: number;
+  category?: string;
+  awardedAt?: Date;
+  isManuallyAwarded?: boolean;
+  metadata?: any;
+  progress?: {
+    current: number;
+    required: number;
+    percentage: number;
+  };
+}
+
+export class UserProfileBadgesDto {
+  totalBadges: number;
+  totalPoints: number;
+  badgesByRarity: Record<BadgeRarity, number>;
+  recentBadges: BadgeResponseDto[];
+  featuredBadges: BadgeResponseDto[];
+}
+
+export class LeaderboardEntryDto {
+  userId: string;
+  username: string;
+  totalScore: number;
+  gamesPlayed: number;
+  badgeCount: number;
+  badgePoints: number;
+  topBadges: BadgeResponseDto[];
+  rank: number;
+}

--- a/src/badge/dto/create-badge.dto.ts
+++ b/src/badge/dto/create-badge.dto.ts
@@ -1,0 +1,59 @@
+import {
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsBoolean,
+  IsNumber,
+  IsObject,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import {
+  AchievementType,
+  BadgeRarity,
+  type BadgeCriteria,
+} from '../entities/badge.entity';
+
+export class CreateBadgeDto {
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @MaxLength(500)
+  description: string;
+
+  @IsString()
+  @MaxLength(255)
+  icon: string;
+
+  @IsEnum(AchievementType)
+  type: AchievementType;
+
+  @IsEnum(BadgeRarity)
+  @IsOptional()
+  rarity?: BadgeRarity = BadgeRarity.COMMON;
+
+  @IsObject()
+  @IsOptional()
+  criteria?: BadgeCriteria;
+
+  @IsBoolean()
+  @IsOptional()
+  isAutoAwarded?: boolean = false;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  points?: number = 0;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  sortOrder?: number = 0;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  category?: string;
+}

--- a/src/badge/dto/update-badge.dto.ts
+++ b/src/badge/dto/update-badge.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateBadgeDto } from './create-badge.dto';
+
+export class UpdateBadgeDto extends PartialType(CreateBadgeDto) {}

--- a/src/badge/entities/badge.entity.ts
+++ b/src/badge/entities/badge.entity.ts
@@ -1,0 +1,91 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToMany,
+  Index,
+} from 'typeorm';
+import { UserBadge } from './user-badge.entity';
+
+export enum AchievementType {
+  GAMEPLAY = 'gameplay',
+  SOCIAL = 'social',
+  EVENT_BASED = 'event_based',
+  MILESTONE = 'milestone',
+  SPECIAL = 'special',
+}
+
+export enum BadgeRarity {
+  COMMON = 'common',
+  UNCOMMON = 'uncommon',
+  RARE = 'rare',
+  EPIC = 'epic',
+  LEGENDARY = 'legendary',
+}
+
+export interface BadgeCriteria {
+  condition: string;
+  value?: number;
+  operator?: 'gte' | 'lte' | 'eq' | 'gt' | 'lt';
+  field?: string;
+  metadata?: Record<string, any>;
+}
+
+@Entity('badges')
+@Index(['type', 'isActive'])
+@Index(['isAutoAwarded', 'isActive'])
+export class Badge {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true, length: 100 })
+  name: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ length: 255 })
+  icon: string;
+
+  @Column({
+    type: 'enum',
+    enum: AchievementType,
+  })
+  type: AchievementType;
+
+  @Column({
+    type: 'enum',
+    enum: BadgeRarity,
+    default: BadgeRarity.COMMON,
+  })
+  rarity: BadgeRarity;
+
+  @Column('jsonb', { nullable: true })
+  criteria: BadgeCriteria;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ default: false })
+  isAutoAwarded: boolean;
+
+  @Column({ default: 0 })
+  points: number;
+
+  @Column({ default: 0 })
+  sortOrder: number;
+
+  @Column({ type: 'text', nullable: true })
+  category: string;
+
+  @OneToMany(() => UserBadge, (userBadge) => userBadge.badge)
+  userBadges: UserBadge[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/badge/entities/user-badge.entity.ts
+++ b/src/badge/entities/user-badge.entity.ts
@@ -1,0 +1,57 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { Badge } from './badge.entity';
+import { User } from '../../user/entities/user.entity';
+
+@Entity('user_badges')
+@Unique(['userId', 'badgeId'])
+@Index(['userId'])
+@Index(['badgeId'])
+@Index(['awardedAt'])
+export class UserBadge {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @Column('uuid')
+  badgeId: string;
+
+  @ManyToOne(() => User, (user) => user.userBadges, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @ManyToOne(() => Badge, (badge) => badge.userBadges, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'badgeId' })
+  badge: Badge;
+
+  @Column({ nullable: true })
+  awardedBy: string;
+
+  @Column({ default: false })
+  isManuallyAwarded: boolean;
+
+  @Column('jsonb', { nullable: true })
+  metadata: {
+    gameId?: string;
+    score?: number;
+    context?: string;
+    triggerEvent?: string;
+    additionalData?: Record<string, any>;
+  };
+
+  @Column({ default: false })
+  isDisplayed: boolean;
+
+  @CreateDateColumn()
+  awardedAt: Date;
+}

--- a/src/badge/services/achievement.service.ts
+++ b/src/badge/services/achievement.service.ts
@@ -1,0 +1,447 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { type Badge, AchievementType } from '../entities/badge.entity';
+import type { UserBadge } from '../entities/user-badge.entity';
+import type { User } from '../../user/entities/user.entity';
+import { type Game, GameStatus } from '../../game/entities/game.entity';
+
+@Injectable()
+export class AchievementService {
+  private readonly logger = new Logger(AchievementService.name);
+
+  constructor(
+    private badgeRepository: Repository<Badge>,
+    private userBadgeRepository: Repository<UserBadge>,
+    private userRepository: Repository<User>,
+    private gameRepository: Repository<Game>,
+  ) {}
+
+  async checkAndAwardAchievements(
+    userId: string,
+    context?: any,
+  ): Promise<UserBadge[]> {
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      this.logger.warn(`User ${userId} not found for achievement check`);
+      return [];
+    }
+
+    const autoAwardedBadges = await this.badgeRepository.find({
+      where: { isAutoAwarded: true, isActive: true },
+    });
+
+    const newlyAwardedBadges: UserBadge[] = [];
+
+    for (const badge of autoAwardedBadges) {
+      const hasAlready = await this.userBadgeRepository.findOne({
+        where: { userId, badgeId: badge.id },
+      });
+
+      if (!hasAlready && (await this.checkCriteria(user, badge, context))) {
+        const userBadge = await this.awardBadgeAutomatically(
+          userId,
+          badge.id,
+          context,
+        );
+        newlyAwardedBadges.push(userBadge);
+        this.logger.log(`Awarded badge "${badge.name}" to user ${userId}`);
+      }
+    }
+
+    return newlyAwardedBadges;
+  }
+
+  private async checkCriteria(
+    user: User,
+    badge: Badge,
+    context?: any,
+  ): Promise<boolean> {
+    if (!badge.criteria) return false;
+
+    const { condition, value, operator = 'gte', field } = badge.criteria;
+
+    try {
+      switch (condition) {
+        case 'games_played':
+          return this.compareValues(user.gamesPlayed, value, operator);
+
+        case 'total_score':
+          return this.compareValues(user.totalScore, value, operator);
+
+        case 'highest_score':
+          return this.compareValues(user.highestScore, value, operator);
+
+        case 'referrals':
+          return this.compareValues(user.referrals, value, operator);
+
+        case 'current_streak':
+          return this.compareValues(user.currentStreak, value, operator);
+
+        case 'longest_streak':
+          return this.compareValues(user.longestStreak, value, operator);
+
+        case 'high_score_game':
+          if (context?.score) {
+            return this.compareValues(context.score, value, operator);
+          }
+          return false;
+
+        case 'first_game':
+          return user.gamesPlayed === 1;
+
+        case 'perfect_score':
+          return (
+            context?.score &&
+            context?.maxPossibleScore &&
+            context.score === context.maxPossibleScore
+          );
+
+        case 'consecutive_wins':
+          return await this.checkConsecutiveWins(user.id, value);
+
+        case 'daily_streak':
+          return await this.checkDailyStreak(user.id, value);
+
+        case 'games_in_timeframe':
+          return await this.checkGamesInTimeframe(
+            user.id,
+            value,
+            badge.criteria.metadata?.timeframe || 'day',
+          );
+
+        case 'score_improvement':
+          return await this.checkScoreImprovement(user.id, value);
+
+        case 'social_referral':
+          return user.referrals >= (value || 1);
+
+        case 'level_reached':
+          return context?.level && context.level >= value;
+
+        case 'game_duration':
+          return (
+            context?.duration &&
+            this.compareValues(context.duration, value, operator)
+          );
+
+        default:
+          this.logger.warn(`Unknown achievement condition: ${condition}`);
+          return false;
+      }
+    } catch (error) {
+      this.logger.error(
+        `Error checking criteria for badge ${badge.name}: ${error.message}`,
+      );
+      return false;
+    }
+  }
+
+  private compareValues(
+    userValue: number,
+    targetValue: number,
+    operator: string,
+  ): boolean {
+    switch (operator) {
+      case 'gte':
+        return userValue >= targetValue;
+      case 'lte':
+        return userValue <= targetValue;
+      case 'eq':
+        return userValue === targetValue;
+      case 'gt':
+        return userValue > targetValue;
+      case 'lt':
+        return userValue < targetValue;
+      default:
+        return false;
+    }
+  }
+
+  private async checkConsecutiveWins(
+    userId: string,
+    requiredWins: number,
+  ): Promise<boolean> {
+    const recentGames = await this.gameRepository.find({
+      where: { userId, status: GameStatus.COMPLETED },
+      order: { createdAt: 'DESC' },
+      take: requiredWins,
+    });
+
+    if (recentGames.length < requiredWins) return false;
+
+    // Check if all recent games are wins (assuming win condition)
+    return recentGames.every((game) => this.isGameWin(game));
+  }
+
+  private async checkDailyStreak(
+    userId: string,
+    requiredDays: number,
+  ): Promise<boolean> {
+    const query = `
+      SELECT COUNT(DISTINCT DATE(created_at)) as streak_days
+      FROM games 
+      WHERE user_id = $1 
+        AND created_at >= NOW() - INTERVAL '${requiredDays} days'
+        AND status = 'completed'
+    `;
+
+    const result = await this.gameRepository.query(query, [userId]);
+    return result[0]?.streak_days >= requiredDays;
+  }
+
+  private async checkGamesInTimeframe(
+    userId: string,
+    requiredGames: number,
+    timeframe: string,
+  ): Promise<boolean> {
+    const intervals = {
+      hour: '1 hour',
+      day: '1 day',
+      week: '7 days',
+      month: '30 days',
+    };
+
+    const interval = intervals[timeframe] || '1 day';
+
+    const query = `
+      SELECT COUNT(*) as game_count
+      FROM games 
+      WHERE user_id = $1 
+        AND created_at >= NOW() - INTERVAL '${interval}'
+        AND status = 'completed'
+    `;
+
+    const result = await this.gameRepository.query(query, [userId]);
+    return result[0]?.game_count >= requiredGames;
+  }
+
+  private async checkScoreImprovement(
+    userId: string,
+    improvementPercentage: number,
+  ): Promise<boolean> {
+    const recentGames = await this.gameRepository.find({
+      where: { userId, status: GameStatus.COMPLETED },
+      order: { createdAt: 'DESC' },
+      take: 10,
+    });
+
+    if (recentGames.length < 2) return false;
+
+    const latestScore = recentGames[0].score;
+    const previousAverage =
+      recentGames.slice(1, 6).reduce((sum, game) => sum + game.score, 0) /
+      Math.min(5, recentGames.length - 1);
+
+    const improvement =
+      ((latestScore - previousAverage) / previousAverage) * 100;
+    return improvement >= improvementPercentage;
+  }
+
+  private isGameWin(game: Game): boolean {
+    // Define win condition based on your game logic
+    // This is a simple example - adjust based on your requirements
+    if (game.maxPossibleScore > 0) {
+      return game.score >= game.maxPossibleScore * 0.7; // 70% of max score is a win
+    }
+    return game.score > 0; // Any positive score is a win
+  }
+
+  private async awardBadgeAutomatically(
+    userId: string,
+    badgeId: string,
+    context?: any,
+  ): Promise<UserBadge> {
+    const userBadge = this.userBadgeRepository.create({
+      userId,
+      badgeId,
+      isManuallyAwarded: false,
+      metadata: context
+        ? {
+            gameId: context.gameId,
+            score: context.score,
+            level: context.level,
+            duration: context.duration,
+            context: 'auto_awarded',
+            triggerEvent: context.triggerEvent || 'game_completion',
+            additionalData: context.additionalData,
+          }
+        : {
+            context: 'auto_awarded',
+            triggerEvent: 'system_check',
+          },
+      isDisplayed: true,
+    });
+
+    return await this.userBadgeRepository.save(userBadge);
+  }
+
+  async initializeDefaultBadges(): Promise<void> {
+    const defaultBadges = [
+      // Gameplay Achievements
+      {
+        name: 'First Steps',
+        description: 'Complete your first game',
+        icon: '🎮',
+        type: AchievementType.GAMEPLAY,
+        isAutoAwarded: true,
+        criteria: { condition: 'first_game' },
+        points: 10,
+        category: 'Getting Started',
+      },
+      {
+        name: 'High Scorer',
+        description: 'Achieve a score of 10,000 or more in a single game',
+        icon: '🎯',
+        type: AchievementType.GAMEPLAY,
+        isAutoAwarded: true,
+        criteria: {
+          condition: 'high_score_game',
+          value: 10000,
+          operator: 'gte',
+        },
+        points: 50,
+        category: 'Performance',
+      },
+      {
+        name: 'Perfectionist',
+        description: 'Achieve a perfect score',
+        icon: '⭐',
+        type: AchievementType.GAMEPLAY,
+        isAutoAwarded: true,
+        criteria: { condition: 'perfect_score' },
+        points: 200,
+        rarity: 'epic',
+        category: 'Excellence',
+      },
+      {
+        name: 'Speed Demon',
+        description: 'Complete a game in under 60 seconds',
+        icon: '⚡',
+        type: AchievementType.GAMEPLAY,
+        isAutoAwarded: true,
+        criteria: { condition: 'game_duration', value: 60, operator: 'lte' },
+        points: 75,
+        rarity: 'rare',
+        category: 'Speed',
+      },
+
+      // Milestone Achievements
+      {
+        name: 'Dedicated Player',
+        description: 'Play 10 games',
+        icon: '🏃',
+        type: AchievementType.MILESTONE,
+        isAutoAwarded: true,
+        criteria: { condition: 'games_played', value: 10, operator: 'gte' },
+        points: 25,
+        category: 'Milestones',
+      },
+      {
+        name: 'Century Club',
+        description: 'Play 100 games',
+        icon: '💯',
+        type: AchievementType.MILESTONE,
+        isAutoAwarded: true,
+        criteria: { condition: 'games_played', value: 100, operator: 'gte' },
+        points: 100,
+        rarity: 'rare',
+        category: 'Milestones',
+      },
+      {
+        name: 'Score Master',
+        description: 'Reach a total score of 100,000',
+        icon: '🏆',
+        type: AchievementType.MILESTONE,
+        isAutoAwarded: true,
+        criteria: { condition: 'total_score', value: 100000, operator: 'gte' },
+        points: 150,
+        rarity: 'epic',
+        category: 'Milestones',
+      },
+
+      // Social Achievements
+      {
+        name: 'Social Butterfly',
+        description: 'Refer 5 friends to the platform',
+        icon: '🦋',
+        type: AchievementType.SOCIAL,
+        isAutoAwarded: true,
+        criteria: { condition: 'referrals', value: 5, operator: 'gte' },
+        points: 75,
+        rarity: 'rare',
+        category: 'Social',
+      },
+      {
+        name: 'Influencer',
+        description: 'Refer 25 friends to the platform',
+        icon: '📢',
+        type: AchievementType.SOCIAL,
+        isAutoAwarded: true,
+        criteria: { condition: 'referrals', value: 25, operator: 'gte' },
+        points: 250,
+        rarity: 'legendary',
+        category: 'Social',
+      },
+
+      // Streak Achievements
+      {
+        name: 'On Fire',
+        description: 'Win 5 games in a row',
+        icon: '🔥',
+        type: AchievementType.GAMEPLAY,
+        isAutoAwarded: true,
+        criteria: { condition: 'consecutive_wins', value: 5 },
+        points: 100,
+        rarity: 'rare',
+        category: 'Streaks',
+      },
+      {
+        name: 'Unstoppable',
+        description: 'Win 10 games in a row',
+        icon: '🚀',
+        type: AchievementType.GAMEPLAY,
+        isAutoAwarded: true,
+        criteria: { condition: 'consecutive_wins', value: 10 },
+        points: 300,
+        rarity: 'legendary',
+        category: 'Streaks',
+      },
+
+      // Special Achievements
+      {
+        name: 'Beta Tester',
+        description: 'Special recognition for beta testing',
+        icon: '🧪',
+        type: AchievementType.SPECIAL,
+        isAutoAwarded: false,
+        points: 150,
+        rarity: 'epic',
+        category: 'Special',
+      },
+      {
+        name: 'Community Champion',
+        description: 'Outstanding contribution to the community',
+        icon: '👑',
+        type: AchievementType.SPECIAL,
+        isAutoAwarded: false,
+        points: 500,
+        rarity: 'legendary',
+        category: 'Special',
+      },
+    ];
+
+    for (const badgeData of defaultBadges) {
+      const existing = await this.badgeRepository.findOne({
+        where: { name: badgeData.name },
+      });
+
+      if (!existing) {
+        const badge = this.badgeRepository.create(badgeData);
+        await this.badgeRepository.save(badge);
+        this.logger.log(`Created default badge: ${badgeData.name}`);
+      }
+    }
+
+    this.logger.log('Default badges initialization completed');
+  }
+}

--- a/src/badge/services/badge.service.ts
+++ b/src/badge/services/badge.service.ts
@@ -1,0 +1,315 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  Logger,
+} from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import {
+  type Badge,
+  type AchievementType,
+  BadgeRarity,
+} from '../entities/badge.entity';
+import type { UserBadge } from '../entities/user-badge.entity';
+import type { User } from '../../user/entities/user.entity';
+import type { CreateBadgeDto } from '../dto/create-badge.dto';
+import type { AwardBadgeDto } from '../dto/award-badge.dto';
+import type {
+  BadgeResponseDto,
+  UserProfileBadgesDto,
+  LeaderboardEntryDto,
+} from '../dto/badge-response.dto';
+
+@Injectable()
+export class BadgeService {
+  private readonly logger = new Logger(BadgeService.name);
+
+  constructor(
+    private badgeRepository: Repository<Badge>,
+    private userBadgeRepository: Repository<UserBadge>,
+    private userRepository: Repository<User>,
+  ) {}
+
+  async createBadge(createBadgeDto: CreateBadgeDto): Promise<Badge> {
+    const existingBadge = await this.badgeRepository.findOne({
+      where: { name: createBadgeDto.name },
+    });
+
+    if (existingBadge) {
+      throw new ConflictException('Badge with this name already exists');
+    }
+
+    const badge = this.badgeRepository.create(createBadgeDto);
+    const savedBadge = await this.badgeRepository.save(badge);
+
+    this.logger.log(`Created new badge: ${savedBadge.name} (${savedBadge.id})`);
+    return savedBadge;
+  }
+
+  async getAllBadges(includeInactive = false): Promise<Badge[]> {
+    const whereCondition = includeInactive ? {} : { isActive: true };
+
+    return await this.badgeRepository.find({
+      where: whereCondition,
+      order: { sortOrder: 'ASC', createdAt: 'DESC' },
+    });
+  }
+
+  async getBadgesByType(type: AchievementType): Promise<Badge[]> {
+    return await this.badgeRepository.find({
+      where: { type, isActive: true },
+      order: { sortOrder: 'ASC', createdAt: 'DESC' },
+    });
+  }
+
+  async getBadgeById(id: string): Promise<Badge> {
+    const badge = await this.badgeRepository.findOne({ where: { id } });
+    if (!badge) {
+      throw new NotFoundException('Badge not found');
+    }
+    return badge;
+  }
+
+  async awardBadgeManually(
+    awardBadgeDto: AwardBadgeDto,
+    adminId: string,
+  ): Promise<UserBadge> {
+    const { userId, badgeId, metadata } = awardBadgeDto;
+
+    // Verify user exists
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Verify badge exists
+    const badge = await this.getBadgeById(badgeId);
+
+    // Check if user already has this badge
+    const existingUserBadge = await this.userBadgeRepository.findOne({
+      where: { userId, badgeId },
+    });
+
+    if (existingUserBadge) {
+      throw new ConflictException('User already has this badge');
+    }
+
+    const userBadge = this.userBadgeRepository.create({
+      userId,
+      badgeId,
+      awardedBy: adminId,
+      isManuallyAwarded: true,
+      metadata: {
+        ...metadata,
+        context: 'manual_award',
+        triggerEvent: 'admin_action',
+      },
+      isDisplayed: true,
+    });
+
+    const savedUserBadge = await this.userBadgeRepository.save(userBadge);
+
+    this.logger.log(
+      `Manually awarded badge "${badge.name}" to user ${user.username} by admin ${adminId}`,
+    );
+
+    return savedUserBadge;
+  }
+
+  async getUserBadges(userId: string): Promise<BadgeResponseDto[]> {
+    const userBadges = await this.userBadgeRepository.find({
+      where: { userId },
+      relations: ['badge'],
+      order: { awardedAt: 'DESC' },
+    });
+
+    return userBadges.map((userBadge) => this.mapToResponseDto(userBadge));
+  }
+
+  async getUserProfileBadges(userId: string): Promise<UserProfileBadgesDto> {
+    const userBadges = await this.userBadgeRepository.find({
+      where: { userId },
+      relations: ['badge'],
+      order: { awardedAt: 'DESC' },
+    });
+
+    const badgesByRarity = userBadges.reduce(
+      (acc, userBadge) => {
+        const rarity = userBadge.badge.rarity;
+        acc[rarity] = (acc[rarity] || 0) + 1;
+        return acc;
+      },
+      {} as Record<BadgeRarity, number>,
+    );
+
+    const totalPoints = userBadges.reduce(
+      (sum, userBadge) => sum + userBadge.badge.points,
+      0,
+    );
+
+    const recentBadges = userBadges
+      .slice(0, 5)
+      .map((userBadge) => this.mapToResponseDto(userBadge));
+
+    const featuredBadges = userBadges
+      .filter(
+        (userBadge) =>
+          userBadge.badge.rarity === BadgeRarity.LEGENDARY ||
+          userBadge.badge.rarity === BadgeRarity.EPIC,
+      )
+      .slice(0, 3)
+      .map((userBadge) => this.mapToResponseDto(userBadge));
+
+    return {
+      totalBadges: userBadges.length,
+      totalPoints,
+      badgesByRarity,
+      recentBadges,
+      featuredBadges,
+    };
+  }
+
+  async getLeaderboardWithBadges(limit = 10): Promise<LeaderboardEntryDto[]> {
+    const query = `
+      SELECT 
+        u.id as "userId",
+        u.username,
+        u.total_score as "totalScore",
+        u.games_played as "gamesPlayed",
+        COUNT(ub.id)::int as "badgeCount",
+        COALESCE(SUM(b.points), 0)::int as "badgePoints",
+        JSON_AGG(
+          JSON_BUILD_OBJECT(
+            'id', b.id,
+            'name', b.name,
+            'icon', b.icon,
+            'rarity', b.rarity,
+            'points', b.points,
+            'awardedAt', ub.awarded_at
+          ) ORDER BY b.rarity DESC, ub.awarded_at DESC
+        ) FILTER (WHERE b.id IS NOT NULL) as "topBadges",
+        ROW_NUMBER() OVER (ORDER BY u.total_score DESC, COALESCE(SUM(b.points), 0) DESC) as rank
+      FROM users u
+      LEFT JOIN user_badges ub ON u.id = ub.user_id
+      LEFT JOIN badges b ON ub.badge_id = b.id AND b.is_active = true
+      WHERE u.is_active = true
+      GROUP BY u.id, u.username, u.total_score, u.games_played
+      ORDER BY u.total_score DESC, "badgePoints" DESC
+      LIMIT $1
+    `;
+
+    const results = await this.userBadgeRepository.query(query, [limit]);
+
+    return results.map((result: any) => ({
+      ...result,
+      topBadges: (result.topBadges || []).slice(0, 3),
+    }));
+  }
+
+  async getBadgeProgress(userId: string, badgeId: string): Promise<any> {
+    const badge = await this.getBadgeById(badgeId);
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (!badge.criteria || !badge.isAutoAwarded) {
+      return null;
+    }
+
+    const progress = await this.calculateProgress(user, badge);
+    return progress;
+  }
+
+  async removeBadgeFromUser(userId: string, badgeId: string): Promise<void> {
+    const userBadge = await this.userBadgeRepository.findOne({
+      where: { userId, badgeId },
+    });
+
+    if (!userBadge) {
+      throw new NotFoundException('User badge not found');
+    }
+
+    await this.userBadgeRepository.remove(userBadge);
+    this.logger.log(`Removed badge ${badgeId} from user ${userId}`);
+  }
+
+  async updateBadge(
+    id: string,
+    updateData: Partial<CreateBadgeDto>,
+  ): Promise<Badge> {
+    const badge = await this.getBadgeById(id);
+
+    if (updateData.name && updateData.name !== badge.name) {
+      const existingBadge = await this.badgeRepository.findOne({
+        where: { name: updateData.name },
+      });
+      if (existingBadge) {
+        throw new ConflictException('Badge with this name already exists');
+      }
+    }
+
+    Object.assign(badge, updateData);
+    return await this.badgeRepository.save(badge);
+  }
+
+  async deactivateBadge(id: string): Promise<Badge> {
+    const badge = await this.getBadgeById(id);
+    badge.isActive = false;
+    return await this.badgeRepository.save(badge);
+  }
+
+  private mapToResponseDto(userBadge: UserBadge): BadgeResponseDto {
+    return {
+      id: userBadge.badge.id,
+      name: userBadge.badge.name,
+      description: userBadge.badge.description,
+      icon: userBadge.badge.icon,
+      type: userBadge.badge.type,
+      rarity: userBadge.badge.rarity,
+      points: userBadge.badge.points,
+      category: userBadge.badge.category,
+      awardedAt: userBadge.awardedAt,
+      isManuallyAwarded: userBadge.isManuallyAwarded,
+      metadata: userBadge.metadata,
+    };
+  }
+
+  private async calculateProgress(user: User, badge: Badge): Promise<any> {
+    const { condition, value, operator = 'gte' } = badge.criteria;
+    let current = 0;
+    const required = value || 1;
+
+    switch (condition) {
+      case 'games_played':
+        current = user.gamesPlayed;
+        break;
+      case 'total_score':
+        current = user.totalScore;
+        break;
+      case 'highest_score':
+        current = user.highestScore;
+        break;
+      case 'referrals':
+        current = user.referrals;
+        break;
+      case 'current_streak':
+        current = user.currentStreak;
+        break;
+      case 'longest_streak':
+        current = user.longestStreak;
+        break;
+      default:
+        return null;
+    }
+
+    const percentage = Math.min((current / required) * 100, 100);
+
+    return {
+      current,
+      required,
+      percentage: Math.round(percentage),
+    };
+  }
+}

--- a/src/common/guards/admin.guard.ts
+++ b/src/common/guards/admin.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { AuthGuard } from './auth.guard';
+import type { Repository } from 'typeorm';
+import type { User } from '../../user/entities/user.entity';
+
+@Injectable()
+export class AdminGuard extends AuthGuard implements CanActivate {
+  constructor(
+    jwtService: any,
+    private userRepository: Repository<User>,
+  ) {
+    super(jwtService);
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isAuthenticated = super.canActivate(context);
+    if (!isAuthenticated) return false;
+
+    const request = context.switchToHttp().getRequest();
+    const user = await this.userRepository.findOne({
+      where: { id: request.user.id },
+    });
+
+    if (!user?.isAdmin) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    return true;
+  }
+}

--- a/src/common/guards/auth.guard.ts
+++ b/src/common/guards/auth.guard.ts
@@ -1,0 +1,34 @@
+import {
+  Injectable,
+  type CanActivate,
+  type ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { JwtService } from '@nestjs/jwt';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private jwtService: JwtService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const token = this.extractTokenFromHeader(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Token not found');
+    }
+
+    try {
+      const payload = this.jwtService.verify(token);
+      request.user = payload;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+
+  private extractTokenFromHeader(request: any): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/src/game/dto/create-game.dto.ts
+++ b/src/game/dto/create-game.dto.ts
@@ -1,0 +1,1 @@
+export class CreateGameDto {}

--- a/src/game/dto/update-game.dto.ts
+++ b/src/game/dto/update-game.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateGameDto } from './create-game.dto';
+
+export class UpdateGameDto extends PartialType(CreateGameDto) {}

--- a/src/game/entities/game.entity.ts
+++ b/src/game/entities/game.entity.ts
@@ -1,0 +1,62 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+export enum GameStatus {
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  ABANDONED = 'abandoned',
+}
+
+@Entity('games')
+@Index(['userId', 'createdAt'])
+@Index(['status'])
+@Index(['score'])
+export class Game {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @Column()
+  score: number;
+
+  @Column({ default: 0 })
+  maxPossibleScore: number;
+
+  @Column({
+    type: 'enum',
+    enum: GameStatus,
+    default: GameStatus.IN_PROGRESS,
+  })
+  status: GameStatus;
+
+  @Column({ default: 0 })
+  duration: number; // in seconds
+
+  @Column({ default: 1 })
+  level: number;
+
+  @Column('jsonb', { nullable: true })
+  gameData: {
+    gameType?: string;
+    difficulty?: string;
+    achievements?: string[];
+    metadata?: Record<string, any>;
+  };
+
+  @ManyToOne(() => User, (user) => user.games, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/game/game.controller.spec.ts
+++ b/src/game/game.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GameController } from './game.controller';
+import { GameService } from './game.service';
+
+describe('GameController', () => {
+  let controller: GameController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GameController],
+      providers: [GameService],
+    }).compile();
+
+    controller = module.get<GameController>(GameController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/game/game.controller.ts
+++ b/src/game/game.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  UseGuards,
+  Request,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { AuthGuard } from '../../auth/guards/auth.guard';
+import { GameService } from './game.service';
+
+@Controller('games')
+@UseGuards(AuthGuard)
+export class GameController {
+  constructor(private readonly gameService: GameService) {}
+
+  @Post()
+  async createGame(
+    gameData: { score: number; gameData?: any },
+    @Request() req,
+  ) {
+    return await this.gameService.createGame(
+      req.user.id,
+      gameData.score,
+      gameData.gameData,
+    );
+  }
+
+  @Get('user/:userId')
+  async getUserGames(@Param('userId', ParseUUIDPipe) userId: string) {
+    return await this.gameService.getUserGames(userId);
+  }
+
+  @Get('user/:userId/stats')
+  async getGameStats(@Param('userId', ParseUUIDPipe) userId: string) {
+    return await this.gameService.getGameStats(userId);
+  }
+}

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Game } from './entities/game.entity';
+import { GameService } from './services/game.service';
+import { GameController } from './controllers/game.controller';
+import { BadgeModule } from '../badge/badge.module';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Game]), BadgeModule, UserModule],
+  controllers: [GameController],
+  providers: [GameService],
+  exports: [TypeOrmModule, GameService],
+})
+export class GameModule {}

--- a/src/game/game.service.spec.ts
+++ b/src/game/game.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GameService } from './game.service';
+
+describe('GameService', () => {
+  let service: GameService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GameService],
+    }).compile();
+
+    service = module.get<GameService>(GameService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { type Game, GameStatus } from '../entities/game.entity';
+import type { AchievementService } from '../../badge/services/achievement.service';
+import type { UserService } from '../../user/services/user.service';
+
+@Injectable()
+export class GameService {
+  private readonly logger = new Logger(GameService.name);
+
+  constructor(
+    private gameRepository: Repository<Game>,
+    private achievementService: AchievementService,
+    private userService: UserService,
+  ) {}
+
+  async createGame(
+    userId: string,
+    score: number,
+    gameData?: any,
+  ): Promise<{ game: Game; newBadges: any[] }> {
+    const game = this.gameRepository.create({
+      userId,
+      score,
+      maxPossibleScore: gameData?.maxPossibleScore || 0,
+      status: GameStatus.COMPLETED,
+      duration: gameData?.duration || 0,
+      level: gameData?.level || 1,
+      gameData,
+    });
+
+    const savedGame = await this.gameRepository.save(game);
+
+    // Update user statistics
+    await this.userService.updateUserStats(userId, {
+      score,
+      maxPossibleScore: gameData?.maxPossibleScore,
+      ...gameData,
+    });
+
+    // Check for achievements
+    const newBadges = await this.achievementService.checkAndAwardAchievements(
+      userId,
+      {
+        gameId: savedGame.id,
+        score,
+        maxPossibleScore: gameData?.maxPossibleScore,
+        level: gameData?.level,
+        duration: gameData?.duration,
+        triggerEvent: 'game_completion',
+        additionalData: gameData,
+      },
+    );
+
+    this.logger.log(
+      `Game completed for user ${userId}. Score: ${score}. New badges: ${newBadges.length}`,
+    );
+
+    return { game: savedGame, newBadges };
+  }
+
+  async getUserGames(userId: string, limit = 10): Promise<Game[]> {
+    return await this.gameRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  async getGameStats(userId: string): Promise<any> {
+    const query = `
+      SELECT 
+        COUNT(*) as total_games,
+        AVG(score) as average_score,
+        MAX(score) as highest_score,
+        SUM(CASE WHEN score > 0 THEN 1 ELSE 0 END) as games_won,
+        AVG(duration) as average_duration
+      FROM games 
+      WHERE user_id = $1 AND status = 'completed'
+    `;
+
+    const result = await this.gameRepository.query(query, [userId]);
+    return result[0];
+  }
+}


### PR DESCRIPTION
This PR adds a complete achievement and badge system that automatically awards badges based on user milestones and allows admin manual assignment.

## Changes Added

- **5 Achievement Types**: Gameplay, Social, Event-based, Milestone, Special
- **Automatic Awarding**: Triggers on game completion, score thresholds, streaks, referrals
- **Manual Assignment**: Admin-only special badge awarding
- **Profile Integration**: Badges displayed in user profiles and leaderboards
- **Security**: Duplicate prevention, role-based access, input validation


## API Endpoints

```plaintext
GET/POST /badges              # Badge management
GET      /badges/user/:id     # User badges
GET      /badges/leaderboard  # Enhanced leaderboard
POST     /badges/award        # Manual award (admin)
```

Closes #47 