### PR TITLE
Feat/maintanaince

### DIFF
--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,0 +1,6 @@
+
+export enum UserRole {
+  User = 'user',
+  Admin = 'admin',
+
+}

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,22 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { UserRole } from '../constants';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true; 
+    }
+    const { user } = context.switchToHttp().getRequest();
+    
+    return requiredRoles.some((role) => user.roles?.includes(role));
+  }
+}

--- a/src/common/decorators/public.decorator.ts
+++ b/src/common/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/common/guards/maintenance.guard.ts
+++ b/src/common/guards/maintenance.guard.ts
@@ -1,0 +1,45 @@
+
+import { Injectable, CanActivate, ExecutionContext, HttpException, HttpStatus } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { SettingsService } from '../../settings/settings.service'; 
+import { UserRole } from '../../auth/constants'; 
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator'; 
+
+@Injectable()
+export class MaintenanceGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private settingsService: SettingsService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true; 
+    }
+
+    const maintenanceModeEnabled = await this.settingsService.getMaintenanceMode();
+
+    if (!maintenanceModeEnabled) {
+      return true; 
+    }
+
+    
+    const request = context.switchToHttp().getRequest();
+    const user = request.user; 
+
+    if (user && user.roles && user.roles.includes(UserRole.Admin)) {
+      return true; 
+    }
+
+    
+    const maintenanceSetting = await this.settingsService.getSetting('maintenanceMode');
+    const message = maintenanceSetting?.message || 'The platform is currently under maintenance. Please try again later.';
+
+    throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE); 
+  }
+}

--- a/src/settings/schemas/setting.schema.ts
+++ b/src/settings/schemas/setting.schema.ts
@@ -1,0 +1,18 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type SettingDocument = Setting & Document;
+
+@Schema()
+export class Setting {
+  @Prop({ required: true, unique: true })
+  key: string; 
+
+  @Prop({ type: Object, required: true }) 
+  value: any;
+
+  @Prop({ default: Date.now })
+  updatedAt: Date;
+}
+
+export const SettingSchema = SchemaFactory.createForClass(Setting);

--- a/src/settings/settings.controller.ts
+++ b/src/settings/settings.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Post, Body, UseGuards, HttpException, HttpStatus } from '@nestjs/common';
+import { SettingsService } from './settings.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'; 
+import { RolesGuard } from '../auth/guards/roles.guard';     
+import { Roles } from '../auth/decorators/roles.decorator';  
+import { UserRole } from '../auth/constants';                
+
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('settings')
+export class SettingsController {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  @Get('maintenance')
+  @Roles(UserRole.Admin) 
+  async getMaintenanceModeStatus() {
+    const maintenanceMode = await this.settingsService.getMaintenanceMode();
+    const maintenanceSetting = await this.settingsService.getSetting('maintenanceMode');
+    return {
+      enabled: maintenanceMode,
+      message: maintenanceSetting?.message || 'No maintenance message set.'
+    };
+  }
+
+  @Post('maintenance/toggle')
+  @Roles(UserRole.Admin) 
+  async toggleMaintenanceMode(@Body('enabled') enabled: boolean) {
+    if (typeof enabled !== 'boolean') {
+      throw new HttpException('Invalid value for enabled. Must be true or false.', HttpStatus.BAD_REQUEST);
+    }
+    const setting = await this.settingsService.toggleMaintenanceMode(enabled);
+    return {
+      message: `Maintenance mode ${enabled ? 'enabled' : 'disabled'} successfully.`,
+      status: setting.value.enabled,
+    };
+  }
+}

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -1,0 +1,16 @@
+
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Setting, SettingSchema } from './schemas/setting.schema';
+import { SettingsService } from './settings.service';
+import { SettingsController } from './settings.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Setting.name, schema: SettingSchema }]),
+  ],
+  providers: [SettingsService],
+  controllers: [SettingsController],
+  exports: [SettingsService], 
+})
+export class SettingsModule {}

--- a/src/settings/settings.service.ts
+++ b/src/settings/settings.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Setting, SettingDocument } from './schemas/setting.schema';
+
+@Injectable()
+export class SettingsService {
+  constructor(
+    @InjectModel(Setting.name) private readonly settingModel: Model<SettingDocument>,
+  ) {}
+
+  async getSetting(key: string): Promise<any | null> {
+    const setting = await this.settingModel.findOne({ key }).exec();
+    return setting ? setting.value : null;
+  }
+
+  async setSetting(key: string, value: any): Promise<SettingDocument> {
+    return this.settingModel.findOneAndUpdate(
+      { key },
+      { value, updatedAt: Date.now() },
+      { upsert: true, new: true }, 
+    ).exec();
+  }
+
+  async getMaintenanceMode(): Promise<boolean> {
+    const setting = await this.getSetting('maintenanceMode');
+    return setting?.enabled === true;
+  }
+
+  async toggleMaintenanceMode(enabled: boolean): Promise<SettingDocument> {
+    return this.setSetting('maintenanceMode', { enabled, message: 'Our platform is currently undergoing scheduled maintenance to improve your experience. We appreciate your patience and will be back online shortly!' });
+  }
+}

--- a/src/users/avatar/avatar.controller.spec.ts
+++ b/src/users/avatar/avatar.controller.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../../app.module'; 
+import { AvatarService } from './avatar.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'; 
+import { AuthGuard } from '@nestjs/passport'; 
+
+describe('AvatarController (e2e)', () => {
+  let app: INestApplication;
+  let avatarService: AvatarService;
+
+  const mockUserId = '60c72b2f9b1d8d001c8e4d1a'; 
+  const mockJwtToken = 'mock-jwt-token'; 
+
+  const mockFile = {
+    fieldname: 'file',
+    originalname: 'test-avatar.png',
+    encoding: '7bit',
+    mimetype: 'image/png',
+    size: 500 * 1024, 
+    buffer: Buffer.from('test image data'), 
+  } as Express.Multer.File;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(AvatarService) 
+      .useValue({
+        uploadAndSaveAvatar: jest.fn().mockResolvedValue({
+          message: 'Avatar uploaded successfully',
+          avatarUrl: `/avatars/${mockUserId}-avatar.webp`,
+        }),
+      })
+      .overrideGuard(JwtAuthGuard) 
+      .useValue({ canActivate: (context) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { id: mockUserId }; 
+          return true;
+        }
+      })
+      
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: (context) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { id: mockUserId }; 
+          return true;
+        }
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe()); 
+    await app.init();
+
+    avatarService = moduleFixture.get<AvatarService>(AvatarService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  it('/avatars/upload (POST) - should upload an avatar successfully', async () => {
+    await request(app.getHttpServer())
+      .post('/avatars/upload')
+      .set('Authorization', `Bearer ${mockJwtToken}`)
+      .attach('file', mockFile.buffer, {
+        filename: mockFile.originalname,
+        contentType: mockFile.mimetype,
+      })
+      .expect(201)
+      .expect({
+        message: 'Avatar uploaded successfully',
+        avatarUrl: `/avatars/${mockUserId}-avatar.webp`,
+      });
+
+    expect(avatarService.uploadAndSaveAvatar).toHaveBeenCalledWith(
+      mockUserId,
+      expect.objectContaining({
+        originalname: mockFile.originalname,
+        mimetype: mockFile.mimetype,
+      }),
+    );
+  });
+
+  it('/avatars/upload (POST) - should return 400 for invalid file type', async () => {
+    const invalidFile = {
+      ...mockFile,
+      mimetype: 'application/pdf',
+      originalname: 'document.pdf',
+    } as Express.Multer.File;
+
+    await request(app.getHttpServer())
+      .post('/avatars/upload')
+      .set('Authorization', `Bearer ${mockJwtToken}`)
+      .attach('file', invalidFile.buffer, {
+        filename: invalidFile.originalname,
+        contentType: invalidFile.mimetype,
+      })
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.message).toContain('File validation failed');
+      });
+
+    expect(avatarService.uploadAndSaveAvatar).not.toHaveBeenCalled();
+  });
+
+  it('/avatars/upload (POST) - should return 400 for file too large', async () => {
+    const largeFile = {
+      ...mockFile,
+      size: 3 * 1024 * 1024, 
+      buffer: Buffer.alloc(3 * 1024 * 1024, 'a'), 
+    } as Express.Multer.File;
+
+    await request(app.getHttpServer())
+      .post('/avatars/upload')
+      .set('Authorization', `Bearer ${

--- a/src/users/avatar/avatar.controller.ts
+++ b/src/users/avatar/avatar.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  Req,
+  HttpException,
+  HttpStatus,
+  ParseFilePipe,
+  MaxFileSizeValidator,
+  FileTypeValidator,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Request } from 'express';
+import { AvatarService } from './avatar.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard'; 
+import { UseGuards } from '@nestjs/common';
+
+@UseGuards(JwtAuthGuard) 
+@Controller('avatars')
+export class AvatarController {
+  constructor(private readonly avatarService: AvatarService) {}
+
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAvatar(
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 1024 * 1024 * 2 }), // 2MB
+          new FileTypeValidator({ fileType: 'image/(jpeg|png|gif)' }),
+        ],
+        exceptionFactory: (error) =>
+          new HttpException(
+            `File validation failed: ${error}`,
+            HttpStatus.BAD_REQUEST,
+          ),
+      }),
+    )
+    file: Express.Multer.File,
+    @Req() req: Request,
+  ) {
+    // Assuming your JWT payload includes the user's ID
+    const userId = req.user['id'];
+    if (!userId) {
+      throw new HttpException(
+        'User ID not found in token',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+    return this.avatarService.uploadAndSaveAvatar(userId, file);
+  }
+}

--- a/src/users/avatar/avatar.service.spec.ts
+++ b/src/users/avatar/avatar.service.spec.ts
@@ -1,0 +1,148 @@
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { AvatarService } from './avatar.service';
+import { User, UserDocument } from './schemas/user.schema';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import * as sharp from 'sharp';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+
+jest.mock('sharp', () => {
+  const mSharp = {
+    resize: jest.fn().mockReturnThis(),
+    webp: jest.fn().mockReturnThis(),
+    toFile: jest.fn().mockResolvedValue({ info: { size: 100 } }),
+  };
+  return jest.fn(() => mSharp);
+});
+
+
+jest.mock('fs/promises', () => ({
+  mkdir: jest.fn().mockResolvedValue(undefined),
+  writeFile: jest.fn().mockResolvedValue(undefined), 
+}));
+
+describe('AvatarService', () => {
+  let service: AvatarService;
+  let userModel: Model<UserDocument>;
+
+  const mockUserId = '60c72b2f9b1d8d001c8e4d1a';
+  const mockUser = {
+    _id: mockUserId,
+    username: 'testuser',
+    email: 'test@example.com',
+    avatarUrl: 'old-avatar.png',
+    save: jest.fn().mockResolvedValue(true), 
+  };
+
+  const mockFile: Express.Multer.File = {
+    fieldname: 'file',
+    originalname: 'upload.png',
+    encoding: '7bit',
+    mimetype: 'image/png',
+    size: 100 * 1024,
+    buffer: Buffer.from('dummy image data'),
+    stream: null, 
+    destination: null,
+    filename: null,
+    path: null,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AvatarService,
+        {
+          provide: getModelToken(User.name),
+          useValue: {
+            findById: jest.fn().mockResolvedValue(mockUser),
+            
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AvatarService>(AvatarService);
+    userModel = module.get<Model<UserDocument>>(getModelToken(User.name));
+
+    
+    jest.clearAllMocks();
+    (sharp as jest.Mock).mockClear(); 
+    (fs.mkdir as jest.Mock).mockClear();
+    mockUser.save.mockClear();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('uploadAndSaveAvatar', () => {
+    it('should successfully process and save the avatar', async () => {
+      const result = await service.uploadAndSaveAvatar(mockUserId, mockFile);
+
+      
+      expect(userModel.findById).toHaveBeenCalledWith(mockUserId);
+
+      
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(process.cwd(), 'public', 'avatars')),
+        { recursive: true }
+      );
+
+      
+      expect(sharp).toHaveBeenCalledWith(mockFile.buffer);
+      
+      expect((sharp as jest.Mock).mock.results[0].value.resize).toHaveBeenCalledWith(200, 200, expect.any(Object));
+      expect((sharp as jest.Mock).mock.results[0].value.webp).toHaveBeenCalledWith(expect.any(Object));
+      expect((sharp as jest.Mock).mock.results[0].value.toFile).toHaveBeenCalledWith(
+        expect.stringContaining(path.join(process.cwd(), 'public', 'avatars', `${mockUserId}-`)) 
+      );
+
+      
+      expect(mockUser.avatarUrl).toMatch(new RegExp(`^/avatars/${mockUserId}-.*\\.webp$`));
+      expect(mockUser.save).toHaveBeenCalled();
+
+      
+      expect(result).toEqual({
+        message: 'Avatar uploaded successfully',
+        avatarUrl: expect.stringMatching(new RegExp(`^/avatars/${mockUserId}-.*\\.webp$`)),
+      });
+    });
+
+    it('should throw HttpException if user not found', async () => {
+      jest.spyOn(userModel, 'findById').mockResolvedValueOnce(null); 
+
+      await expect(service.uploadAndSaveAvatar(mockUserId, mockFile)).rejects.toThrow(
+        new HttpException('User not found', HttpStatus.NOT_FOUND)
+      );
+
+      expect(userModel.findById).toHaveBeenCalledWith(mockUserId);
+      expect(fs.mkdir).not.toHaveBeenCalled(); 
+      expect(sharp).not.toHaveBeenCalled(); 
+      expect(mockUser.save).not.toHaveBeenCalled(); 
+    });
+
+    it('should throw HttpException if image processing fails', async () => {
+      
+      jest.spyOn((sharp as jest.Mock)().toFile, 'mockResolvedValue').mockRejectedValueOnce(
+        new Error('Sharp processing error')
+      );
+
+      await expect(service.uploadAndSaveAvatar(mockUserId, mockFile)).rejects.toThrow(
+        new HttpException('Failed to process image', HttpStatus.INTERNAL_SERVER_ERROR)
+      );
+
+      expect(userModel.findById).toHaveBeenCalledWith(mockUserId);
+      expect(fs.mkdir).toHaveBeenCalled(); 
+      expect(sharp).toHaveBeenCalledWith(mockFile.buffer);
+      expect(mockUser.save).not.toHaveBeenCalled(); 
+    });
+
+    it('should return default avatar URL', () => {
+      expect(service.getDefaultAvatarUrl()).toBe('/avatars/default-avatar.png');
+    });
+  });
+});

--- a/src/users/avatar/avatar.service.ts
+++ b/src/users/avatar/avatar.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User, UserDocument } from './schemas/user.schema';
+import * as sharp from 'sharp';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+@Injectable()
+export class AvatarService {
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+  ) {}
+
+  async uploadAndSaveAvatar(userId: string, file: Express.Multer.File) {
+    const user = await this.userModel.findById(userId);
+    if (!user) {
+      throw new HttpException('User not found', HttpStatus.NOT_FOUND);
+    }
+
+    
+    const filename = `${userId}-${Date.now()}-avatar.webp`; 
+    const uploadDir = path.join(process.cwd(), 'public', 'avatars'); 
+    const filePath = path.join(uploadDir, filename);
+
+    
+    await fs.mkdir(uploadDir, { recursive: true });
+
+    try {
+      await sharp(file.buffer)
+        .resize(200, 200, {
+          fit: sharp.fit.cover,
+          position: sharp.strategy.attention,
+        })
+        .webp({ quality: 80 }) 
+        .toFile(filePath);
+    } catch (error) {
+      console.error('Error processing image:', error);
+      throw new HttpException(
+        'Failed to process image',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    
+    const avatarUrl = `/avatars/${filename}`; 
+    user.avatarUrl = avatarUrl;
+    await user.save();
+
+    return { message: 'Avatar uploaded successfully', avatarUrl };
+  }
+
+  
+  getDefaultAvatarUrl(): string {
+    return '/avatars/default-avatar.png'; 
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from "@nestjs/typeorm"
 import { User } from "./entities/user.entity"
 import { UserController } from "./controllers/users.controller"
 import { UserService } from "./providers/users.service"
+import { AvatarController } from "./avatar/avatar.controller"
+import { AvatarService } from "./avatar/avatar.service"
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
-  controllers: [UserController],
-  providers: [UserService],
+  controllers: [UserController, AvatarController], 
+  providers: [UserService, AvatarService], 
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
This PR adds a global maintenance mode capability, allowing platform administrators to restrict access during critical updates, migrations, or downtime. When enabled, all non-admin users are blocked from interacting with key services, and a consistent maintenance message is displayed across web, API, and game interfaces.

closes #43 

