### PR TITLE
Implemented daily challenges

### DIFF
--- a/src/scheduled-challenges/controllers/daily-challenge.controller.ts
+++ b/src/scheduled-challenges/controllers/daily-challenge.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { DailyChallengeService } from '../services/daily-challenge.service';
+
+@Controller('challenges/daily')
+export class DailyChallengeController {
+  constructor(private readonly dailyChallengeService: DailyChallengeService) {}
+
+  @Get('current')
+  getCurrentChallenge() {
+    return this.dailyChallengeService.getCurrentChallenge();
+  }
+
+  @Get('history')
+  getChallengeHistory(@Query('limit') limit = 10) {
+    return this.dailyChallengeService.getChallengeHistory(Number(limit));
+  }
+
+  @Get('leaderboard/:challengeId')
+  getLeaderboard(@Param('challengeId') challengeId: string, @Query('limit') limit = 50) {
+    return this.dailyChallengeService.getChallengeLeaderboard(challengeId, Number(limit));
+  }
+}

--- a/src/scheduled-challenges/scheduled-challenges.module.ts
+++ b/src/scheduled-challenges/scheduled-challenges.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DailyChallenge } from './entities/daily-challenge.entity';
+import { DailyChallengeService } from './services/daily-challenge.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DailyChallenge])],
+  providers: [DailyChallengeService],
+  exports: [DailyChallengeService],
+})
+export class ScheduledChallengesModule {}


### PR DESCRIPTION
📚 Overview
Introduce daily challenges that reset every 24 hours to drive player engagement and offer time-bound competition. Each challenge will have unique objectives and contribute to a daily leaderboard with rewards.

🛠️ Tasks
🔹 1. Challenge Scheduling Logic
Create a service under:
src/scheduled-challenges/services/daily-challenge.service.ts

Use a scheduler like @nestjs/schedule or node-cron to:

Generate a new challenge every 24 hours (e.g., midnight UTC)

Archive the previous day's challenge

Each challenge should have:

id, startAt, endAt, objective, reward, isActive

🔹 2. Endpoints
GET /challenges/daily/current
→ Returns the active challenge for the day

GET /challenges/daily/history?limit=10
→ Returns a paginated list of past challenges

GET /challenges/daily/leaderboard/:challengeId
→ Returns the leaderboard for a specific daily challenge

🔹 3. Leaderboard Integration
Integrate daily challenge results into the leaderboard system

Use player performance metrics to compute rankings

Automatically close submissions and finalize rankings at challenge expiration

🔹 4. Optional: Admin Config Panel
Allow admin to:

Manually trigger a daily reset

Create custom challenge objectives (via future CMS or UI)

✅ Acceptance Criteria
✅ New daily challenge is automatically scheduled every 24 hours

✅ Old challenge is archived or marked as inactive

✅ Players can:

View current challenge (/challenges/daily/current)

View past challenges and their leaderboards

✅ Leaderboard updates reflect player performance in daily challenges

✅ Challenge lifecycle is logged and traceable (e.g., via events or logs)

✅ Full test coverage for:

Scheduling logic

Challenge transitions

Challenge retrieval endpoints